### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: Validate formatting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dirkmueller/slacky/security/code-scanning/5](https://github.com/dirkmueller/slacky/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs read-only operations (e.g., checking out the repository and running a linter), we will set `contents: read` as the minimal required permission. This ensures that the workflow does not have unnecessary write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
